### PR TITLE
markdown format for ChaosDAO description

### DIFF
--- a/registry/kusama.json
+++ b/registry/kusama.json
@@ -12,7 +12,7 @@
         "name": "ChaosDAO",
         "image": "https://raw.githubusercontent.com/nova-wallet/opengov-delegate-registry/master/images/chaosdao.png",
         "shortDescription": "Community org with a dedicated internal voting process and multisig for OpenGov referenda",
-        "longDescription": "ChaosDAO is a curated community of Polkadot & Kusama natives. Our members are involved with every aspect of the ecosystem as developers, community organizers, Twitter and YouTube educators, and as ordinary retail investors. As part of our own organization’s evolution we have developed a robust internal governance mechanism to determine how our community will publicly vote on referenda. By voting on behalf of the long-time Dotsama community we hope to ensure that only referenda that benefit the ecosystem are voted in.",
+        "longDescription": "## About us\nChaosDAO is a curated community of Polkadot & Kusama natives. Our members are involved with every aspect of the ecosystem as developers, community organizers, [Twitter](https://twitter.com/ChaosDAO) and YouTube educators, and as ordinary retail investors.\n\n## Voting Process\nAs part of our own organization’s evolution we have developed a robust [internal governance mechanism](https://github.com/ChaosDAO-org/ChaosDAO_docs/blob/main/governance/OpenGov.md) to determine how our community will publicly vote on referenda. By voting on behalf of the long-time Dotsama community we strive to ensure that all votes we cast reflect the true best interests of our native ecosystem.\n\n![ChaosDAO Manifesto image](https://raw.githubusercontent.com/ChaosDAO-org/ChaosDAO_docs/main/.gitbook/assets/ChaosDAO_Manifesto_600px.jpg)",
         "isOrganization": true
     },
     {


### PR DESCRIPTION
restructure ChaosDAO description now that we can see that Anton's description uses Markdown format.

Instead of describing our internal voting process in detail, I've left that detail in the link to our gitbook docs (so it's easy for us to update in the future).